### PR TITLE
#1: Allow specifying pgbouncer settings db key

### DIFF
--- a/resources/connection.rb
+++ b/resources/connection.rb
@@ -27,6 +27,8 @@ attribute :db_name, :kind_of => String, :required => true
 
 attribute :userlist, :kind_of => Hash, :required => true
 
+attribute :db_ref, :kind_of => String
+
 attribute :listen_addr, :kind_of => String
 attribute :listen_port, :kind_of => String
 

--- a/templates/default/etc/pgbouncer/pgbouncer2.ini.erb
+++ b/templates/default/etc/pgbouncer/pgbouncer2.ini.erb
@@ -5,7 +5,7 @@
 ;;   client_encoding= datestyle= timezone=
 ;;   pool_size= connect_query=
 [databases]
-<%= @db_alias %> = host=<%= @db_host %> port=<%= @db_port %> dbname=<%= @db_name %> <%= "connect_query='#{@connect_query}'" unless @connect_query.nil? || @connect_query.empty? %>
+<%= (@db_ref.nil? || @db_ref.empty?)? @db_alias: @db_ref %> = host=<%= @db_host %> port=<%= @db_port %> dbname=<%= @db_name %> <%= "connect_query='#{@connect_query}'" unless @connect_query.nil? || @connect_query.empty? %>
  
 ;; Configuration section
 [pgbouncer]


### PR DESCRIPTION
This allows us to use the wildcard (*) as a key to properly support
testing database creation
