### PR TITLE
5: Fix logrotate scripts

### DIFF
--- a/providers/connection.rb
+++ b/providers/connection.rb
@@ -143,11 +143,20 @@ action :setup do
     action :create
   end
 
-  # build the userlist, pgbouncer.ini and logrotate.d templates
+  # logrotate.d config
+  template "/etc/logrotate.d/pgbouncer-#{new_resource.db_alias}" do
+    cookbook 'pgbouncer'
+    source 'etc/logrotate.d/pgbouncer-logrotate.d.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(template_variables)
+  end
+
+  # build the userlist and pgbouncer.ini templates
   {
     "/etc/pgbouncer/userlist-#{new_resource.db_alias}.txt" => 'etc/pgbouncer/userlist2.txt.erb',
     "/etc/pgbouncer/pgbouncer-#{new_resource.db_alias}.ini" => 'etc/pgbouncer/pgbouncer2.ini.erb', 
-    "/etc/logrotate.d/pgbouncer-#{new_resource.db_alias}" => 'etc/logrotate.d/pgbouncer-logrotate.d.erb', 
   }.each do |key, source_template|
     ## We are setting destination_file to a duplicate of key because the hash
     ## key is frozen and immutable.
@@ -163,9 +172,6 @@ action :setup do
       variables(template_variables)
     end
   end
-
-#      notifies :restart, "service[pgbouncer-#{new_resource.db_alias}]"
-
 
   if init_system == 'upstart'
     data = {

--- a/templates/default/etc/logrotate.d/pgbouncer-logrotate.d.erb
+++ b/templates/default/etc/logrotate.d/pgbouncer-logrotate.d.erb
@@ -1,6 +1,7 @@
 # Rotate postgresql log files
 
 <%= @log_dir %>/pgbouncer-<%= @db_alias %>.log {
+  su <%= @user %> <%= @group %>
   daily
   copytruncate
   missingok


### PR DESCRIPTION
Logrotate config for pgbouncer has two problems:

- The logrotate config should be owned by root but it is owned by pgbouncer
- The logrotate config user/group should be specified to be pgbouncer